### PR TITLE
增加对sqlite数据库的兼容性

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -112,7 +112,7 @@ if($adapterName == 'pgsql' || $adapterName == 'Pdo_Pgsql' || $adapterName == 'Pd
 $sql = $db->select()->from('table.contents') 
 ->where('status = ?','publish')
 ->where('type = ?', 'post')
-->where('created <= unix_timestamp(now())', 'post') //添加这一句避免未达到时间的文章提前曝光
+->where('created <= '. Helper::options()->gmtTime, 'post') //添加这一句避免未达到时间的文章提前曝光
 ->limit($defaults['number'])
 ->order($order_by);
 $result = $db->fetchAll($sql);


### PR DESCRIPTION
原版在sqlite数据库环境下会报错:
no such function: now

因为sqlite不支持mysql里面的now函数。我做了一点点修改，增加对sqlite数据库的兼容性。